### PR TITLE
Fix packed array typing

### DIFF
--- a/ComputeWorker/Example/ComputeExample.gd
+++ b/ComputeWorker/Example/ComputeExample.gd
@@ -3,11 +3,6 @@ extends Node3D
 # This simple example demonstrates setting intial uniform data,
 # and the setting and getting of uniform data, including Structs.
 
-# The `time` variable is accumulated and updated each frame,
-# and the shader returns `result`, a dvec4 in the form of a Color,
-# which contains the `test_vector` in rg, `test_float` in b, and the `time` in the alpha channel.
-# A randomized array of objects is also passed into the shader every frame
-
 @export var test_vector: Vector3 = Vector3(0, 0, 0)
 var test_shader_file = preload("res://ComputeWorker/Example/test_glsl.glsl")
 
@@ -18,10 +13,33 @@ func _ready():
 	var test_vector_uniform: GPU_Vector3 = $ComputeWorker.get_uniform_by_alias("test_vector")
 	test_vector_uniform.data = test_vector
 	
+	
+	# The float array is defined as a uniform buffer in our shader,
+	# and thus can't be dynamically sized. So it's good practice to
+	# use the `array_size` value from the Uniform object that was set in the editor.
+	var float_arr = PackedFloat64Array()
+	var float_arr_uniform = $ComputeWorker.get_uniform_by_alias("fl_arr", 1)
+	
+	float_arr.resize(float_arr_uniform.array_size)
+	float_arr_uniform.data = float_arr
+	
+	
+	# The vector array is defined as a storage buffer,
+	# and thus is dynamically sized (because it's last in the storage block).
+	# We can pass in whatever size array we want here.
+	var vec_arr = PackedVector3Array()
+	vec_arr.resize(200)
+	
+	var vec_arr_uniform = $ComputeWorker.get_uniform_by_alias("vec_arr", 1)
+	vec_arr_uniform.data = vec_arr
+	
+	
 	$ComputeWorker.initialize()
 
 
 func _process(delta):
+	
+	var dispatch = false
 	
 	# An example of how to restart the ComputeWorker with a new shader.
 	if Input.is_key_pressed(KEY_SPACE):
@@ -30,29 +48,40 @@ func _process(delta):
 		$ComputeWorker.shader_file = test_shader_file
 		$ComputeWorker.initialize()
 	
+	
 	if $ComputeWorker.initialized:
 	
-		# Here we add `delta` to the uniform's current data to get an accumulated time inside the shader.
+		# Here we add `delta` to the time uniform's current data to get an accumulated time inside the shader.
 		var gpu_time = $ComputeWorker.get_uniform_data_by_alias("time")
-		$ComputeWorker.set_uniform_data_by_alias(gpu_time + delta, "time", 0, false)
+		$ComputeWorker.set_uniform_data_by_alias(gpu_time + delta, "time", 0, dispatch)
 		
-		# Grab a list of (randomized for demo's sake) objects matching the struct's format, and pass it into the shader.
-		var obj_arr = get_random_obj_array()
-		$ComputeWorker.set_uniform_data_by_alias(obj_arr, "obj_arr", 0, false)
+		
+		# Grab a list of struct objects matching the struct's format, and pass it into the shader.
+		var obj_arr = get_obj_array()
+		$ComputeWorker.set_uniform_data_by_alias(obj_arr, "obj_arr", 0, dispatch)
+		
+		
+		# Note that we didn't dispatch the shader until this point. This is for multiple reasons:
+		#     1. We don't want to wait for the shader to execute multiple times in a single frame.
+		#     2. We want to make sure the shader has all the data necessary for computation before executing.
+		dispatch = true
 		
 		# Assign a random value to `test_float` in set 1, and dispatch.
 		var rand_float = randf() * 100
-		$ComputeWorker.set_uniform_data_by_alias(rand_float, "test_float", 1)
+		$ComputeWorker.set_uniform_data_by_alias(rand_float, "test_float", 1, dispatch)
+		
 		
 		# Poll the result of the shader execution. (result == Color(test_vector.xy, test_float, time))
 		var result = $ComputeWorker.get_uniform_data_by_alias("result")
-		print(result)
+		print($ComputeWorker.get_uniform_data_by_alias("result", 0))
 
 
 # Generates a list of struct objects to pass into the shader.
 # The array must be the same length as defined in the uniform.
-func get_random_obj_array() -> Array[Array]:
+func get_obj_array() -> Array[Array]:
 	
+	# Here we get the StructArray uniform and grab its `struct_data`
+	# to use as a template for our array elements.
 	var uniform: GPU_StructArray = $ComputeWorker.get_uniform_by_alias("obj_arr")
 	var structure = uniform.struct_data
 	
@@ -61,13 +90,6 @@ func get_random_obj_array() -> Array[Array]:
 	for i in range(uniform.array_size):
 		
 		var struct = structure.duplicate()
-		
-		# Assign random values to the floats, just for some visible changes.
-		for x in range(struct.size()):
-			match typeof(struct[x]):
-				TYPE_FLOAT:
-					struct[x] += randf() * 100
-			
 		obj_arr.push_back(struct)
 		
 	return obj_arr

--- a/ComputeWorker/Example/ComputeExample.tscn
+++ b/ComputeWorker/Example/ComputeExample.tscn
@@ -1,20 +1,22 @@
-[gd_scene load_steps=18 format=3 uid="uid://lq0tmmd28v6m"]
+[gd_scene load_steps=22 format=3 uid="uid://lq0tmmd28v6m"]
 
 [ext_resource type="Script" path="res://ComputeWorker/Example/ComputeExample.gd" id="1_be2gl"]
 [ext_resource type="Script" path="res://ComputeWorker/ComputeWorker.gd" id="1_xl0l0"]
-[ext_resource type="RDShaderFile" uid="uid://ymm2bjkxkunr" path="res://ComputeWorker/Example/test_glsl.glsl" id="2_fgw4v"]
+[ext_resource type="RDShaderFile" uid="uid://dqjpwysd5wl32" path="res://ComputeWorker/Example/test_glsl.glsl" id="2_fgw4v"]
 [ext_resource type="Script" path="res://ComputeWorker/UniformSets/UniformSet.gd" id="4_qss55"]
 [ext_resource type="Script" path="res://ComputeWorker/GPUUniforms/GPU_Float.gd" id="5_66svv"]
 [ext_resource type="Script" path="res://ComputeWorker/GPUUniforms/GPU_StructArray.gd" id="6_s3exw"]
 [ext_resource type="Script" path="res://ComputeWorker/GPUUniforms/GPU_Vector3.gd" id="7_8e7d6"]
 [ext_resource type="Script" path="res://ComputeWorker/GPUUniforms/GPU_Integer.gd" id="8_bbhsn"]
 [ext_resource type="Script" path="res://ComputeWorker/GPUUniforms/GPU_Color.gd" id="8_qrxf1"]
+[ext_resource type="Script" path="res://ComputeWorker/GPUUniforms/GPU_PackedFloat64Array.gd" id="10_016bp"]
+[ext_resource type="Script" path="res://ComputeWorker/GPUUniforms/GPU_PackedVector3Array.gd" id="11_txkll"]
 
 [sub_resource type="Resource" id="Resource_ntob8"]
 script = ExtResource("5_66svv")
 data = 0.0
 binding = 0
-uniform_type = 1
+uniform_type = 0
 alias = "time"
 
 [sub_resource type="Resource" id="Resource_n5517"]
@@ -43,12 +45,12 @@ alias = "result"
 script = ExtResource("8_bbhsn")
 data = 0
 binding = 4
-uniform_type = 1
+uniform_type = 0
 alias = "test_int"
 
 [sub_resource type="Resource" id="Resource_x6x0r"]
 script = ExtResource("4_qss55")
-uniforms = [SubResource("Resource_ntob8"), SubResource("Resource_n5517"), SubResource("Resource_3jhqj"), SubResource("Resource_4orwy"), SubResource("Resource_civi2")]
+uniforms = Array[Resource("res://ComputeWorker/GPUUniforms/GPUUniform.gd")]([SubResource("Resource_ntob8"), SubResource("Resource_n5517"), SubResource("Resource_3jhqj"), SubResource("Resource_4orwy"), SubResource("Resource_civi2")])
 set_id = 0
 
 [sub_resource type="Resource" id="Resource_213ay"]
@@ -58,9 +60,25 @@ binding = 0
 uniform_type = 1
 alias = "test_float"
 
+[sub_resource type="Resource" id="Resource_kq8sp"]
+script = ExtResource("10_016bp")
+data = null
+array_size = 100
+binding = 1
+uniform_type = 0
+alias = "fl_arr"
+
+[sub_resource type="Resource" id="Resource_seqiu"]
+script = ExtResource("11_txkll")
+data = null
+array_size = 100
+binding = 2
+uniform_type = 1
+alias = "vec_arr"
+
 [sub_resource type="Resource" id="Resource_fxcho"]
 script = ExtResource("4_qss55")
-uniforms = [SubResource("Resource_213ay")]
+uniforms = Array[Resource("res://ComputeWorker/GPUUniforms/GPUUniform.gd")]([SubResource("Resource_213ay"), SubResource("Resource_kq8sp"), SubResource("Resource_seqiu")])
 set_id = 1
 
 [node name="ComputeExample" type="Node3D"]
@@ -70,4 +88,4 @@ test_vector = Vector3(2.02, 3, 300)
 [node name="ComputeWorker" type="Node" parent="."]
 script = ExtResource("1_xl0l0")
 shader_file = ExtResource("2_fgw4v")
-uniform_sets = [SubResource("Resource_x6x0r"), SubResource("Resource_fxcho")]
+uniform_sets = Array[ExtResource("4_qss55")]([SubResource("Resource_x6x0r"), SubResource("Resource_fxcho")])

--- a/ComputeWorker/Example/test_glsl.glsl
+++ b/ComputeWorker/Example/test_glsl.glsl
@@ -4,6 +4,7 @@
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
 
+
 struct Object{
     dvec4 position;
     dvec4 velocity;
@@ -12,28 +13,36 @@ struct Object{
     double effector;
 };
 
-layout(set = 0, binding = 0, std430) buffer Globals{
+layout(set = 0, binding = 0, std140) uniform Time{
     double time;
 };
 
-layout(set = 0, binding = 1, std430) buffer ObjectArray{
+layout(set = 0, binding = 1, std430) buffer TestStructArray{
     Object obj_arr[10];
 };
 
-layout(set = 0, binding = 2, std430) buffer Vector{
+layout(set = 0, binding = 2, std430) buffer TestVector{
     dvec4 test_vector;
 };
 
-layout(set = 0, binding = 3, std430) buffer Result{
+layout(set = 0, binding = 3, std430) buffer LookupResult{
     dvec4 result;
 };
 
-layout(set = 0, binding = 4, std430) buffer Integer{
+layout(set = 0, binding = 4, std140) uniform TestInteger{
     int test_int;
 };
 
-layout(set = 1, binding = 0, std430) buffer TestSet{
+layout(set = 1, binding = 0, std430) buffer TestFloat{
     double test_float;
+};
+
+layout(set = 1, binding = 1, std140) uniform TestFloatArr{
+    double[100] fl_arr;
+};
+
+layout(set = 1, binding = 2, std430) buffer TestVecArr{
+    vec4[] vec_arr;
 };
 
 void main() {

--- a/ComputeWorker/GPUUniforms/GPU_PackedFloat64Array.gd
+++ b/ComputeWorker/GPUUniforms/GPU_PackedFloat64Array.gd
@@ -9,7 +9,9 @@ enum UNIFORM_TYPES{
 }
 
 ## The initial data supplied to the uniform
-@export var data: PackedFloat64Array
+@export var data: PackedFloat64Array = PackedFloat64Array()
+## The size of the array as defined in the shader. Only used if `data` is not defined.
+@export var array_size: int = 0
 ## The shader binding for this uniform
 @export var binding: int = 0
 ## Type of uniform to create. `UNIFORM_BUFFER`s cannot be altered from within the shader
@@ -20,6 +22,13 @@ var uniform: RDUniform = RDUniform.new()
 
 
 func initialize(rd: RenderingDevice) -> RDUniform:
+	
+	if data.is_empty():
+		if array_size > 0:
+			data.resize(array_size)
+		else:
+			printerr("You must define the uniform's `data` or `array_size`.")
+			return
 	
 	# Create the buffer using our initial data
 	data_rid = create_rid(rd)
@@ -50,6 +59,7 @@ func create_rid(rd: RenderingDevice) -> RID:
 	
 	match uniform_type:
 		UNIFORM_TYPES.UNIFORM_BUFFER:
+			bytes = pad_byte_array_std140(bytes)
 			buffer = rd.uniform_buffer_create(bytes.size(), bytes)
 		UNIFORM_TYPES.STORAGE_BUFFER:
 			buffer = rd.storage_buffer_create(bytes.size(), bytes)
@@ -65,3 +75,17 @@ func get_uniform_data(rd: RenderingDevice) -> PackedFloat64Array:
 func set_uniform_data(rd: RenderingDevice, array: PackedFloat64Array) -> void:
 	var sb_data = array.to_byte_array()
 	rd.buffer_update(data_rid, 0 , sb_data.size(), sb_data)
+
+
+func pad_byte_array_std140(arr: PackedByteArray) -> PackedByteArray:
+	
+	arr.resize(arr.size() * 2)
+	var next_offset = 0
+	
+	for i in range(arr.size()):
+		if next_offset + 8 > arr.size():
+			break
+		arr.encode_double(next_offset + 8, 0.0)
+		next_offset += 16
+	
+	return arr

--- a/ComputeWorker/GPUUniforms/GPU_PackedFloat64Array.gd
+++ b/ComputeWorker/GPUUniforms/GPU_PackedFloat64Array.gd
@@ -9,7 +9,7 @@ enum UNIFORM_TYPES{
 }
 
 ## The initial data supplied to the uniform
-@export var data: Array[float] = Array()
+@export var data: PackedFloat64Array
 ## The shader binding for this uniform
 @export var binding: int = 0
 ## Type of uniform to create. `UNIFORM_BUFFER`s cannot be altered from within the shader
@@ -44,7 +44,7 @@ func create_uniform() -> RDUniform:
 
 func create_rid(rd: RenderingDevice) -> RID:
 	
-	var bytes = PackedFloat64Array(data).to_byte_array()
+	var bytes = data.to_byte_array()
 	
 	var buffer: RID = RID()
 	
@@ -57,11 +57,11 @@ func create_rid(rd: RenderingDevice) -> RID:
 	return buffer
 
 
-func get_uniform_data(rd: RenderingDevice) -> Array[float]:
+func get_uniform_data(rd: RenderingDevice) -> PackedFloat64Array:
 	var out := rd.buffer_get_data(data_rid)
-	return byte_array_64_to_float_array(out)
+	return out.to_float64_array()
 
 
-func set_uniform_data(rd: RenderingDevice, array: Array[float]) -> void:
-	var sb_data = float_array_to_byte_array_64(array)
+func set_uniform_data(rd: RenderingDevice, array: PackedFloat64Array) -> void:
+	var sb_data = array.to_byte_array()
 	rd.buffer_update(data_rid, 0 , sb_data.size(), sb_data)

--- a/ComputeWorker/GPUUniforms/GPU_PackedVector3Array.gd
+++ b/ComputeWorker/GPUUniforms/GPU_PackedVector3Array.gd
@@ -9,7 +9,9 @@ enum UNIFORM_TYPES{
 }
 
 ## The initial data supplied to the uniform
-@export var data: PackedVector3Array
+@export var data: PackedVector3Array = PackedVector3Array()
+## The size of the array as defined in the shader. Only used if `data` is not defined.
+@export var array_size: int = 0
 ## The shader binding for this uniform
 @export var binding: int = 0
 ## Type of uniform to create. `UNIFORM_BUFFER`s cannot be altered from within the shader
@@ -20,6 +22,13 @@ var uniform: RDUniform = RDUniform.new()
 
 
 func initialize(rd: RenderingDevice) -> RDUniform:
+	
+	if data.is_empty():
+		
+		assert(array_size > 0, "You must define the uniform's `data` or `array_size`.")
+		
+		if array_size > 0:
+			data.resize(array_size)
 	
 	# Create the buffer using our initial data
 	data_rid = create_rid(rd)
@@ -44,7 +53,7 @@ func create_uniform() -> RDUniform:
 
 func create_rid(rd: RenderingDevice) -> RID:
 	
-	var bytes = data.to_byte_array()
+	var bytes = vec3_array_to_byte_array(data)
 	
 	var buffer: RID = RID()
 	

--- a/ComputeWorker/GPUUniforms/GPU_PackedVector3Array.gd
+++ b/ComputeWorker/GPUUniforms/GPU_PackedVector3Array.gd
@@ -9,7 +9,7 @@ enum UNIFORM_TYPES{
 }
 
 ## The initial data supplied to the uniform
-@export var data: Array[Vector3] = Array()
+@export var data: PackedVector3Array
 ## The shader binding for this uniform
 @export var binding: int = 0
 ## Type of uniform to create. `UNIFORM_BUFFER`s cannot be altered from within the shader
@@ -44,8 +44,8 @@ func create_uniform() -> RDUniform:
 
 func create_rid(rd: RenderingDevice) -> RID:
 	
-	var bytes = vec3_array_to_byte_array(data)
-	print(bytes)
+	var bytes = data.to_byte_array()
+	
 	var buffer: RID = RID()
 	
 	match uniform_type:
@@ -57,12 +57,12 @@ func create_rid(rd: RenderingDevice) -> RID:
 	return buffer
 
 
-func get_uniform_data(rd: RenderingDevice) -> Array[Vector3]:
+func get_uniform_data(rd: RenderingDevice) -> PackedVector3Array:
 	var out := rd.buffer_get_data(data_rid)
 	return byte_array_to_vec3_array(out)
 
 
-func set_uniform_data(rd: RenderingDevice, array: Array[Vector3]) -> void:
+func set_uniform_data(rd: RenderingDevice, array: PackedVector3Array) -> void:
 	var sb_data = vec3_array_to_byte_array(array)
 	rd.buffer_update(data_rid, 0 , sb_data.size(), sb_data)
 


### PR DESCRIPTION
Fixes a problem with PackedFloat64Array and PackedVector3Array where they were using Array[Variant] types for their data instead of their actual intended `Packed***` data formats.

Also updated the example scene/script to include examples of dynamic storage buffer arrays and statically sized uniform buffer arrays. 